### PR TITLE
Correcting a prominent typo

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -7,7 +7,7 @@ title: Sneakers | Performance Background Processing for Ruby
       <img src="<%= image_path("main_logo.png") %>" width="300px" alt="Sneakers - Performance Background Processing For Ruby"/>
     </div>
     <h1>Sneakers</h1>
-    <h3 class="sectiontitle">High Performance Backround Jobs. On Ruby.</h3>
+    <h3 class="sectiontitle">High Performance Background Jobs. On Ruby.</h3>
     <a href="http://rubygems.org/gems/sneakers">
       <img src="https://img.shields.io/gem/v/sneakers.svg" alt="Version"/>
       <img src="https://img.shields.io/gem/dt/sneakers.svg" alt="Downloads"/>


### PR DESCRIPTION
"Backround" -> "Background" on index page
